### PR TITLE
⚗️ Try to restore gha workflow

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -9,8 +9,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # concurrency:
-    #   group: ${{ github.workflow }}-${{ github.ref }}
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -8,9 +8,9 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+    runs-on: ubuntu-latest
+    # concurrency:
+    #   group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use the latest Ubuntu runner and comments out the concurrency settings.

Changes to `.github/workflows/gh-pages.yaml`:

* Updated the `runs-on` field to use `ubuntu-latest` instead of `ubuntu-20.04` for the deploy job.
* Commented out the `concurrency` settings in the deploy job, disabling the grouping by workflow and reference.